### PR TITLE
Add Dockerfile and config files for NGINX.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,2 @@
+FROM nginx
+COPY conf.d/ /etc/nginx/conf.d/

--- a/conf.d/technocore.stream
+++ b/conf.d/technocore.stream
@@ -1,0 +1,60 @@
+upstream mqtt_cluster {
+    server mqtt:1883;
+}
+
+server {
+    listen 1883; # MQTT port
+    proxy_pass mqtt_cluster;
+
+    access_log /var/log/nginx/mqtt_access.log main;
+    error_log  /var/log/nginx/mqtt_error.log info; # nginScript debug logging
+}
+
+# TODO: Implement secure MQTT as well as other sites. Below is a starting point.
+#server {
+#    listen 8883 ssl; # MQTT secure port
+#    #preread_buffer_size 1k;
+#    #js_preread getClientId;
+
+#    ssl_certificate /run/secrets/cert;
+#    ssl_certificate_key /run/secrets/key;
+#    ssl_ciphers         HIGH:!aNULL:!MD5;
+#    ssl_session_cache   shared:SSL:128m; # 128MB ~= 500k sessions
+#    ssl_session_tickets on;
+#    ssl_session_timeout 8h;
+
+#    location * {
+#        proxy_pass mqtt://mqtt:8883;
+#        proxy_connect_timeout 1s;
+
+#    }
+
+#    #access_log /var/log/nginx/mqtt_access.log debug;
+#    error_log  /var/log/nginx/mqtt_error.log info; # nginScript debug logging
+#}
+
+#server {
+#    listen 80;
+#    server_name mqtt.scifi.farm,spencer-laptop;
+#
+#    location /.well-known/acme-challenge/ {
+#        root /var/www/certbot;
+#    }
+#
+#    location / {
+#        return 301 https://$host$request_uri;
+#    }
+#}
+
+#server {
+#    listen 443 ssl;
+#    server_name mqtt.scifi.farm,spencer-laptop;
+#
+#    ssl_certificate /run/secrets/cert;
+#    ssl_certificate_key /run/secrets/key;
+#    include /etc/letsencrypt/options-ssl-nginx.conf;
+#    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
+#
+#    location / {
+#        proxy_pass ;
+#    }

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,36 @@
+user  nginx;
+worker_processes  1;
+
+error_log  /var/log/nginx/error.log warn;
+pid        /var/run/nginx.pid;
+
+
+events {
+    worker_connections  1024;
+}
+
+# For MQTT
+# https://serverfault.com/questions/883073/nginx-emerg-stream-directive-is-not-allowed-here
+stream {
+    include /etc/nginx/conf.d/*.stream;
+}
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /var/log/nginx/access.log  main;
+
+    sendfile        on;
+    #tcp_nopush     on;
+
+    keepalive_timeout  65;
+
+    #gzip  on;
+
+    include /etc/nginx/conf.d/*.conf;
+}


### PR DESCRIPTION
This pull request contains the initial code for getting NGINX forwarding MQTT traffic. It does not do HTTPS and the code I have commented out is likely not going to work. But it's still a good starting point. 

For more on what else needs to happen in the NGINX service, see 
https://github.com/SciFiFarms/TechnoCore/issues/5

I took the nginx.conf file from the image and added the stream {} include. This allowed me to forward streams rather than just http services. 
https://serverfault.com/questions/883073/nginx-emerg-stream-directive-is-not-allowed-here